### PR TITLE
Add IAccessTokenRequirement

### DIFF
--- a/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
@@ -2,9 +2,11 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Altinn.Common.AccessToken.Configuration;
 using Altinn.Common.AccessToken.Constants;
 using Altinn.Common.AccessToken.Services;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -12,163 +14,162 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 
-namespace Altinn.Common.AccessToken
-{
-    /// <summary>
-    /// Authorization handler to verify that request contains access token
-    /// </summary>
-    public class AccessTokenHandler : AuthorizationHandler<AccessTokenRequirement>
-    {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly ILogger _logger;
-        private readonly AccessTokenSettings _accessTokenSettings;
-        private readonly ISigningKeysResolver _signingKeysResolver;
+namespace Altinn.Common.AccessToken;
 
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        /// <param name="httpContextAccessor">Default httpContext accessor</param>
-        /// <param name="logger">The logger</param>
-        /// <param name="accessTokenSettings">The access token settings</param>
-        /// <param name="signingKeysResolver">The resolver for signing keys</param>
-        public AccessTokenHandler(
-            IHttpContextAccessor httpContextAccessor,
-            ILogger<AccessTokenHandler> logger,
-            IOptions<AccessTokenSettings> accessTokenSettings,
-            ISigningKeysResolver signingKeysResolver)
+/// <summary>
+/// Authorization handler to verify that request contains access token
+/// </summary>
+public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger _logger;
+    private readonly AccessTokenSettings _accessTokenSettings;
+    private readonly ISigningKeysResolver _signingKeysResolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class with the given parameters.
+    /// </summary>
+    /// <param name="httpContextAccessor">A service that provides access to the current HttpContext.</param>
+    /// <param name="logger">A logger</param>
+    /// <param name="accessTokenSettings">The access token settings</param>
+    /// <param name="signingKeysResolver">The resolver for signing keys</param>
+    public AccessTokenHandler(
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<AccessTokenHandler> logger,
+        IOptions<AccessTokenSettings> accessTokenSettings,
+        ISigningKeysResolver signingKeysResolver)
+    {
+            _httpContextAccessor = httpContextAccessor;
+            _logger = logger;
+            _accessTokenSettings = accessTokenSettings.Value;
+            _signingKeysResolver = signingKeysResolver;
+    }
+
+    /// <summary>
+    /// Handles verification of AccessTokens. Enabled with Policy on API controllers 
+    /// </summary>
+    /// <param name="context">The context</param>
+    /// <param name="requirement">The requirement for the given operation</param>
+    /// <returns></returns>
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, IAccessTokenRequirement requirement)
+    {
+        StringValues tokens = GetAccessTokens();
+        if (tokens.Count != 1 && _accessTokenSettings.DisableAccessTokenVerification)
         {
-                _httpContextAccessor = httpContextAccessor;
-                _logger = logger;
-                _accessTokenSettings = accessTokenSettings.Value;
-                _signingKeysResolver = signingKeysResolver;
+            _logger.LogWarning("Token is missing and function is turned of");
+            context.Succeed(requirement);
+            return;
         }
 
-        /// <summary>
-        /// Handles verification of AccessTokens. Enabled with Policy on API controllers 
-        /// </summary>
-        /// <param name="context">The context</param>
-        /// <param name="requirement">The requirement for the given operation</param>
-        /// <returns></returns>
-        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, AccessTokenRequirement requirement)
+        // It should only be one accesss token
+        if (tokens.Count != 1)
         {
-            StringValues tokens = GetAccessTokens();
-            if (tokens.Count != 1 && _accessTokenSettings.DisableAccessTokenVerification)
-            {
-                _logger.LogWarning("Token is missing and function is turned of");
-                context.Succeed(requirement);
-                return;
-            }
+            _logger.LogWarning("Missing Access token");
+            context.Fail();
+            return;
+        }
 
-            // It should only be one accesss token
-            if (tokens.Count != 1)
+        bool isValid = false;
+        try
+        {
+            isValid = await ValidateAccessToken(tokens[0]);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Validation of Access Token Failed");
+            if (!_accessTokenSettings.DisableAccessTokenVerification)
             {
-                _logger.LogWarning("Missing Access token");
                 context.Fail();
                 return;
-            }
-
-            bool isValid = false;
-            try
-            {
-                isValid = await ValidateAccessToken(tokens[0]);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Validation of Access Token Failed");
-                if (!_accessTokenSettings.DisableAccessTokenVerification)
-                {
-                    context.Fail();
-                    return;
-                }
-                else
-                {
-                    context.Succeed(requirement);
-                    return;
-                }
-            }
-
-            if (isValid)
-            {
-                context.Succeed(requirement);
             }
             else
             {
-                context.Fail();
+                context.Succeed(requirement);
+                return;
             }
         }
 
-        /// <summary>
-        /// This validates the access token available in 
-        /// </summary>
-        /// <param name="token">The access token</param>
-        /// <returns></returns>
-        private async Task<bool> ValidateAccessToken(string token)
+        if (isValid)
         {
-            JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
+            context.Succeed(requirement);
+        }
+        else
+        {
+            context.Fail();
+        }
+    }
 
-            if (!validator.CanReadToken(token))
-            {
-                return false;               
-            }
+    /// <summary>
+    /// This validates the access token available in 
+    /// </summary>
+    /// <param name="token">The access token</param>
+    /// <returns></returns>
+    private async Task<bool> ValidateAccessToken(string token)
+    {
+        JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
 
-            // Read JWT token to extract Issuer
-            JwtSecurityToken jwt = validator.ReadJwtToken(token);
-            TokenValidationParameters validationParameters = await GetTokenValidationParameters(jwt.Issuer);
-
-            SecurityToken validatedToken;
-            try
-            {
-                ClaimsPrincipal prinicpal = validator.ValidateToken(token, validationParameters, out validatedToken);
-                SetAccessTokenCredential(validatedToken.Issuer, prinicpal);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to validate token from issuer {Issuer}.", jwt.Issuer);
-            }
-
+        if (!validator.CanReadToken(token))
+        {
             return false;
         }
 
-        private async Task<TokenValidationParameters> GetTokenValidationParameters(string issuer)
-        {
-            TokenValidationParameters tokenValidationParameters = new TokenValidationParameters
-            {
-                ValidateIssuerSigningKey = true,
-                ValidateIssuer = false,
-                ValidateAudience = false,
-                RequireExpirationTime = true,
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
-            };
+        // Read JWT token to extract Issuer
+        JwtSecurityToken jwt = validator.ReadJwtToken(token);
+        TokenValidationParameters validationParameters = await GetTokenValidationParameters(jwt.Issuer);
 
-            tokenValidationParameters.IssuerSigningKeys = await _signingKeysResolver.GetSigningKeys(issuer);
-            return tokenValidationParameters;
+        SecurityToken validatedToken;
+        try
+        {
+            ClaimsPrincipal prinicpal = validator.ValidateToken(token, validationParameters, out validatedToken);
+            SetAccessTokenCredential(validatedToken.Issuer, prinicpal);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to validate token from issuer {Issuer}.", jwt.Issuer);
         }
 
-        private StringValues GetAccessTokens()
+        return false;
+    }
+
+    private async Task<TokenValidationParameters> GetTokenValidationParameters(string issuer)
+    {
+        TokenValidationParameters tokenValidationParameters = new TokenValidationParameters
         {
-            if (_httpContextAccessor.HttpContext.Request.Headers.ContainsKey(_accessTokenSettings.AccessTokenHeaderId))
+            ValidateIssuerSigningKey = true,
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            RequireExpirationTime = true,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+
+        tokenValidationParameters.IssuerSigningKeys = await _signingKeysResolver.GetSigningKeys(issuer);
+        return tokenValidationParameters;
+    }
+
+    private StringValues GetAccessTokens()
+    {
+        if (_httpContextAccessor.HttpContext.Request.Headers.ContainsKey(_accessTokenSettings.AccessTokenHeaderId))
+        {
+            return _httpContextAccessor.HttpContext.Request.Headers[_accessTokenSettings.AccessTokenHeaderId];
+        }
+
+        return StringValues.Empty;
+    }
+
+    private void SetAccessTokenCredential(string issuer, ClaimsPrincipal claimsPrincipal)
+    {
+        string appClaim = string.Empty;
+        foreach (Claim claim in claimsPrincipal.Claims)
+        {
+            if (claim.Type.Equals(AccessTokenClaimTypes.App))
             {
-                return _httpContextAccessor.HttpContext.Request.Headers[_accessTokenSettings.AccessTokenHeaderId];
+                appClaim = claim.Value;
+                break;
             }
-
-            return StringValues.Empty;
         }
 
-        private void SetAccessTokenCredential(string issuer, ClaimsPrincipal claimsPrincipal)
-        {
-            string appClaim = string.Empty;
-            foreach (Claim claim in claimsPrincipal.Claims)
-            {
-                if (claim.Type.Equals(AccessTokenClaimTypes.App))
-                {
-                    appClaim = claim.Value;
-                    break;
-                }
-            }
-
-            _httpContextAccessor.HttpContext.Items.Add(_accessTokenSettings.AccessTokenHttpContextId, issuer + "/" + appClaim);
-        }
+        _httpContextAccessor.HttpContext.Items.Add(_accessTokenSettings.AccessTokenHttpContextId, issuer + "/" + appClaim);
     }
 }

--- a/src/Altinn.Common.AccessToken/AccessTokenRequirement.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenRequirement.cs
@@ -1,17 +1,16 @@
-using Microsoft.AspNetCore.Authorization;
+#nullable enable
 
-namespace Altinn.Common.AccessToken
+namespace Altinn.Common.AccessToken;
+
+/// <summary>
+/// The requirement used in an authorization policy to verify an access token.
+/// </summary>
+public class AccessTokenRequirement : IAccessTokenRequirement
 {
     /// <summary>
-    /// The requirement used to enable access token verification
+    /// Initializes a new instance of the <see cref="AccessTokenRequirement"/> class.
     /// </summary>
-    public class AccessTokenRequirement : IAuthorizationRequirement
+    public AccessTokenRequirement()
     {
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        public AccessTokenRequirement()
-        {
-        }
     }
 }

--- a/src/Altinn.Common.AccessToken/IAccessTokenRequirement.cs
+++ b/src/Altinn.Common.AccessToken/IAccessTokenRequirement.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Altinn.Common.AccessToken;
+
+/// <summary>
+/// This interface describes the implementation of an access token requirement in policy based authorization.
+/// </summary>
+public interface IAccessTokenRequirement : IAuthorizationRequirement
+{
+}


### PR DESCRIPTION
## Description
Adding an interface to describe an access token requirement. The goal is to make it easier/possible to create additional requirements that can use the implemented AuthorizationHandler in combination with other handlers.

In Events we are in need of a requirement that can do both Scope and AccessToken verification and succeed if one of them resolves successfully.

https://learn.microsoft.com/en-us/aspnet/core/security/authorization/policies?view=aspnetcore-7.0#why-would-i-want-multiple-handlers-for-a-requirement