### PR TITLE
Fix for requiring certain issuer(s) of platform/accesstoken with backward compatibility

### DIFF
--- a/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
@@ -70,7 +70,7 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
 
         try
         {
-            bool isValid = await ValidateAccessToken(tokens[0]);
+            bool isValid = await ValidateAccessToken(tokens[0], requirement.ApprovedIssuers);
 
             if (isValid)
             {
@@ -92,8 +92,9 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
     /// This validates the access token available in 
     /// </summary>
     /// <param name="token">The access token</param>
+    /// <param name="ApprovedIssuers">The list of approved issuers</param>
     /// <returns></returns>
-    private async Task<bool> ValidateAccessToken(string token)
+    private async Task<bool> ValidateAccessToken(string token, string[] ApprovedIssuers)
     {
         JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
 
@@ -104,6 +105,13 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
 
         // Read JWT token to extract Issuer
         JwtSecurityToken jwt = validator.ReadJwtToken(token);
+
+        // When no exact match on token issuer against approved issuers
+        if (ApprovedIssuers.Length > 0 && Array.IndexOf(ApprovedIssuers, jwt.Issuer) < 0)
+        {
+            return false;
+        }
+
         TokenValidationParameters validationParameters = await GetTokenValidationParameters(jwt.Issuer);
 
         SecurityToken validatedToken;

--- a/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
@@ -92,9 +92,9 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
     /// This validates the access token available in 
     /// </summary>
     /// <param name="token">The access token</param>
-    /// <param name="ApprovedIssuers">The list of approved issuers</param>
+    /// <param name="approvedIssuers">The list of approved issuers</param>
     /// <returns></returns>
-    private async Task<bool> ValidateAccessToken(string token, string[] ApprovedIssuers)
+    private async Task<bool> ValidateAccessToken(string token, string[] approvedIssuers)
     {
         JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
 
@@ -107,7 +107,7 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
         JwtSecurityToken jwt = validator.ReadJwtToken(token);
 
         // When no exact match on token issuer against approved issuers
-        if (ApprovedIssuers.Length > 0 && Array.IndexOf(ApprovedIssuers, jwt.Issuer) < 0)
+        if (approvedIssuers.Length > 0 && Array.IndexOf(approvedIssuers, jwt.Issuer) < 0)
         {
             return false;
         }

--- a/src/Altinn.Common.AccessToken/AccessTokenRequirement.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenRequirement.cs
@@ -8,9 +8,33 @@ namespace Altinn.Common.AccessToken;
 public class AccessTokenRequirement : IAccessTokenRequirement
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AccessTokenRequirement"/> class.
+    /// Gets the list of approved issuers to validate against.
+    /// </summary>
+    public string[] ApprovedIssuers { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccessTokenRequirement"/> class with no specified issuer.
     /// </summary>
     public AccessTokenRequirement()
     {
+        ApprovedIssuers = new string[] { };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccessTokenRequirement"/> class with a single issuer.
+    /// </summary>
+    /// <param name="issuer">The issuer to validate against.</param>
+    public AccessTokenRequirement(string issuer)
+    {
+        ApprovedIssuers = new string[] { issuer };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccessTokenRequirement"/> class with multiple approved issuers.
+    /// </summary>
+    /// <param name="approvedIssuers">The list of approved issuers to validate against.</param>
+    public AccessTokenRequirement(string[] approvedIssuers)
+    {
+        ApprovedIssuers = approvedIssuers;
     }
 }

--- a/src/Altinn.Common.AccessToken/Altinn.Common.AccessToken.csproj
+++ b/src/Altinn.Common.AccessToken/Altinn.Common.AccessToken.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
 
     <!-- NuGet package properties -->
     <IsPackable>true</IsPackable>
     <PackageId>Altinn.Common.AccessToken</PackageId>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <PackageTags>Altinn;AccessToken</PackageTags>
     <Description>
       Package to verify Access Tokens from client. Require public certificates stored in Azure KeyVault.

--- a/src/Altinn.Common.AccessToken/IAccessTokenRequirement.cs
+++ b/src/Altinn.Common.AccessToken/IAccessTokenRequirement.cs
@@ -9,4 +9,8 @@ namespace Altinn.Common.AccessToken;
 /// </summary>
 public interface IAccessTokenRequirement : IAuthorizationRequirement
 {
+    /// <summary>
+    /// Gets the list of approved issuers to validate against.
+    /// </summary>
+    public string[] ApprovedIssuers { get; }
 }

--- a/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
+++ b/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
@@ -205,5 +205,147 @@ namespace Altinn.AccessToken.Tests
             // Assert
             Assert.True(context.HasSucceeded);
         }
+
+        [Fact]
+        public async Task HandleAsyncTest_SingleApprovedTokenIssuerEqualToMainTokenIssuer_ResultSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("PlatformAccessToken", accessToken);
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            List<IAuthorizationRequirement> _reqsWithSingleSpecifiedIssuer = new List<IAuthorizationRequirement>
+            {
+                new AccessTokenRequirement("ttd")
+            };
+
+            var context = new AuthorizationHandlerContext(_reqsWithSingleSpecifiedIssuer, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleAsyncTest_SingleApprovedTokenIssuerNotEqualToMainTokenIssuer_ResultNotSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("PlatformAccessToken", accessToken);
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            List<IAuthorizationRequirement> _reqsWithSingleSpecifiedIssuer = new List<IAuthorizationRequirement>
+            {
+                new AccessTokenRequirement("ttd1")
+            };
+
+            var context = new AuthorizationHandlerContext(_reqsWithSingleSpecifiedIssuer, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleAsyncTest_MultipleApprovedTokenIssuerAndMainTokenIssuerInThem_ResultSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("PlatformAccessToken", accessToken);
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            List<IAuthorizationRequirement> _reqsWithMultipleSpecifiedIssuers = new List<IAuthorizationRequirement>
+            {
+                new AccessTokenRequirement(
+                    new string[]
+                    {
+                        "ttd",
+                        "ttd1",
+                        "ttd2",
+                    }
+                )
+            };
+
+            var context = new AuthorizationHandlerContext(_reqsWithMultipleSpecifiedIssuers, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleAsyncTest_MultipleApprovedTokenIssuerAndMainTokenIssuerNotInThem_ResultNotSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add("PlatformAccessToken", accessToken);
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            List<IAuthorizationRequirement> _reqsWithMultipleSpecifiedIssuers = new List<IAuthorizationRequirement>
+            {
+                new AccessTokenRequirement(
+                    new string[]
+                    {
+                        "ttd0",
+                        "ttd1",
+                        "ttd2",
+                    }
+                )
+            };
+
+            var context = new AuthorizationHandlerContext(_reqsWithMultipleSpecifiedIssuers, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.False(context.HasSucceeded);
+        }
     }
 }


### PR DESCRIPTION
FIX #21 

`AccesTokenHandler` will perform a check for exact match on token issuer against approved issuers listed in the `ApprovedIssuers` property in `AccessTokenRequirement`. And it is getting done before the token validation as token validation is unnecessary unless the issuer is approved.

## Description
- [x] Expanded the `IAccessTokenRequirement` with `ApprovedIssuers` property for listing the allowed issuers
- [x] Initialized the `ApprovedIssuers` property in `AccessTokenRequirement` class.
  - Used constructor alternatives for
    - No specified issuer
    - Only one issuer
    - Multiple allowed issuers
- [x] Adapted logic in `AccessTokenHandler` to check issuer against the allowed issuers array
  - **Backward Compatibility:** Empty `ApprovedIssuers` property will be resulting in the same outcome as before, means if no specific issuer(s) has been set when instantiating the class object, it'll work as before.
- [x] 4 unit tests has been written for the new functionality.

## Related Issue(s)
- #21 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
