### PR TITLE
Update logging in negative validation cases

### DIFF
--- a/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
@@ -55,14 +55,20 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
     {
         StringValues tokens = GetAccessTokens();
 
-        if (tokens.Count != 1 && _accessTokenSettings.DisableAccessTokenVerification)
+        if (tokens.Count == 0 && _accessTokenSettings.DisableAccessTokenVerification)
         {
-            _logger.LogWarning("Token is missing and function is turned of");
+            _logger.LogWarning("Token is missing and function is turned off");
             context.Succeed(requirement);
             return;
         }
 
-        if (tokens.Count != 1)
+        if (tokens.Count == 0)
+        {
+            _logger.LogInformation("There is no access token");
+            return;
+        }
+        
+        if (tokens.Count > 1)
         {
             _logger.LogWarning("There should be one accesss token");
             return;

--- a/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
+++ b/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
@@ -92,7 +92,7 @@ namespace Altinn.AccessToken.Tests
         }
 
         [Fact]
-        public async Task HandleAsyncTest_TokenExpiredAndVerificationEnabled_ResultSuccessful()
+        public async Task HandleAsyncTest_TokenExpiredAndVerificationEnabled_ResultNotSuccessful()
         {
             // Arrange
             AccessTokenSettings accessTokenSettings = new();
@@ -103,6 +103,33 @@ namespace Altinn.AccessToken.Tests
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            var context = new AuthorizationHandlerContext(_reqs, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleAsyncTest_TwoTokens_ResultNotSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["PlatformAccessToken"] = $"{accessToken};{accessToken};";
 
             _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
 

--- a/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
+++ b/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
@@ -119,33 +119,6 @@ namespace Altinn.AccessToken.Tests
         }
 
         [Fact]
-        public async Task HandleAsyncTest_TwoTokens_ResultNotSuccessful()
-        {
-            // Arrange
-            AccessTokenSettings accessTokenSettings = new();
-            _options.Setup(s => s.Value).Returns(accessTokenSettings);
-
-            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
-
-            DefaultHttpContext httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers["PlatformAccessToken"] = $"{accessToken};{accessToken};";
-
-            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
-
-            var context = new AuthorizationHandlerContext(_reqs, PrincipalUtil.CreateClaimsPrincipal(), null);
-
-            var target = new AccessTokenHandler(
-                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
-
-            // Act
-            await target.HandleAsync(context);
-
-            // Assert
-            Assert.False(context.HasSucceeded);
-        }
-
-        [Fact]
         public async Task HandleAsyncTest_TokenValidAndVerificationEnabled_ResultSuccessful()
         {
             // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently a number of warnings are logged in the applications that use the access token library when the access token is missing from a request. In many cases this might be due to a dual policy requiring either an access token or a different mechanism. 

Changed log to be only information in non-exceptional cases. 

Changed checks to reflect the error messages

## Related Issue(s)
- altinn/altinn-notifications#392

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
