### PR TITLE
#81 Instead of credentials, certificate caching implemented for around an hour

### DIFF
--- a/src/Altinn.Common.AccessTokenClient/Configuration/AccessTokenSettings.cs
+++ b/src/Altinn.Common.AccessTokenClient/Configuration/AccessTokenSettings.cs
@@ -16,6 +16,11 @@ namespace Altinn.Common.AccessTokenClient.Configuration
         public int TokenLifetimeInSeconds { get; set; } = 300;
 
         /// <summary>
+        /// The lifetime for a certificate
+        /// </summary>
+        public int CertificateLifetimeInSeconds { get; set; } = 3600;
+
+        /// <summary>
         /// Specify the number of seconds to add (or subtract) to the current time when determining
         /// when the access token should be considered valid
         /// </summary>

--- a/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
+++ b/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Altinn.Common.AccessTokenClient.Configuration;
@@ -12,7 +13,8 @@ namespace Altinn.Common.AccessTokenClient.Services
     public class SigningCredentialsResolver : ISigningCredentialsResolver
     {
         private readonly AccessTokenSettings _accessTokenSettings;
-        private static X509SigningCredentials _x509SigningCredentials = null;
+        private static X509Certificate2 _cert = null;
+        private static DateTime _expiryTime;
         private static readonly object _lockObject = new object();
 
         /// <summary>
@@ -36,21 +38,20 @@ namespace Altinn.Common.AccessTokenClient.Services
         // Static method to make sonarcloud happy (not update static field from instance method)
         private static SigningCredentials GetSigningCredentials(AccessTokenSettings accessTokenSettings)
         {
-            if (_x509SigningCredentials == null)
+            if (_expiryTime > DateTime.UtcNow && _cert != null)
             {
-                lock (_lockObject)
-                {
-                    if (_x509SigningCredentials == null)
-                    {
-                        string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
-                        string certPath = basePath + $"{accessTokenSettings.AccessTokenSigningKeysFolder}{accessTokenSettings.AccessTokenSigningCertificateFileName}";
-                        X509Certificate2 cert = new X509Certificate2(certPath);
-                        _x509SigningCredentials = new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
-                    }
-                }
+                return new X509SigningCredentials(_cert, SecurityAlgorithms.RsaSha256);
             }
 
-            return _x509SigningCredentials;
+            lock (_lockObject)
+            {
+                string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
+                string certPath = basePath + $"{accessTokenSettings.AccessTokenSigningKeysFolder}{accessTokenSettings.AccessTokenSigningCertificateFileName}";
+                _cert = new X509Certificate2(certPath);
+                _expiryTime = DateTime.UtcNow.AddSeconds(accessTokenSettings.CertificateLifetimeInSeconds - 5); // Set the expiry time to one hour from now
+            }
+
+            return new X509SigningCredentials(_cert, SecurityAlgorithms.RsaSha256);
         }
     }
 }

--- a/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
+++ b/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
@@ -14,7 +14,7 @@ namespace Altinn.Common.AccessTokenClient.Services
     {
         private readonly AccessTokenSettings _accessTokenSettings;
         private static X509Certificate2 _cert = null;
-        private static DateTime _expiryTime;
+        private static DateTime _expiryTime = DateTime.MinValue;
         private static readonly object _lockObject = new object();
 
         /// <summary>
@@ -24,7 +24,6 @@ namespace Altinn.Common.AccessTokenClient.Services
         public SigningCredentialsResolver(IOptions<AccessTokenSettings> accessTokenSettings)
         {
             _accessTokenSettings = accessTokenSettings.Value;
-            _expiryTime = DateTime.MinValue;
         }
 
         /// <summary>

--- a/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
+++ b/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
@@ -24,6 +24,7 @@ namespace Altinn.Common.AccessTokenClient.Services
         public SigningCredentialsResolver(IOptions<AccessTokenSettings> accessTokenSettings)
         {
             _accessTokenSettings = accessTokenSettings.Value;
+            _expiryTime = DateTime.MinValue;
         }
 
         /// <summary>

--- a/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
+++ b/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
@@ -48,7 +48,7 @@ namespace Altinn.Common.AccessTokenClient.Services
                 string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
                 string certPath = basePath + $"{accessTokenSettings.AccessTokenSigningKeysFolder}{accessTokenSettings.AccessTokenSigningCertificateFileName}";
                 _cert = new X509Certificate2(certPath);
-                _reloadTime = DateTime.UtcNow.AddSeconds(accessTokenSettings.CertificateLifetimeInSeconds); // Set the expiry time to one hour from now
+                _reloadTime = DateTime.UtcNow.AddSeconds(accessTokenSettings.CertificateLifetimeInSeconds);
             }
 
             return new X509SigningCredentials(_cert, SecurityAlgorithms.RsaSha256);

--- a/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
+++ b/src/Altinn.Common.AccessTokenClient/Services/SigningCredentialsResolver.cs
@@ -14,7 +14,7 @@ namespace Altinn.Common.AccessTokenClient.Services
     {
         private readonly AccessTokenSettings _accessTokenSettings;
         private static X509Certificate2 _cert = null;
-        private static DateTime _expiryTime = DateTime.MinValue;
+        private static DateTime _reloadTime = DateTime.MinValue;
         private static readonly object _lockObject = new object();
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Altinn.Common.AccessTokenClient.Services
         // Static method to make sonarcloud happy (not update static field from instance method)
         private static SigningCredentials GetSigningCredentials(AccessTokenSettings accessTokenSettings)
         {
-            if (_expiryTime > DateTime.UtcNow && _cert != null)
+            if (_reloadTime > DateTime.UtcNow && _cert != null)
             {
                 return new X509SigningCredentials(_cert, SecurityAlgorithms.RsaSha256);
             }
@@ -48,7 +48,7 @@ namespace Altinn.Common.AccessTokenClient.Services
                 string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
                 string certPath = basePath + $"{accessTokenSettings.AccessTokenSigningKeysFolder}{accessTokenSettings.AccessTokenSigningCertificateFileName}";
                 _cert = new X509Certificate2(certPath);
-                _expiryTime = DateTime.UtcNow.AddSeconds(accessTokenSettings.CertificateLifetimeInSeconds - 5); // Set the expiry time to one hour from now
+                _reloadTime = DateTime.UtcNow.AddSeconds(accessTokenSettings.CertificateLifetimeInSeconds); // Set the expiry time to one hour from now
             }
 
             return new X509SigningCredentials(_cert, SecurityAlgorithms.RsaSha256);


### PR DESCRIPTION
Instead of credentials, certificate caching implemented for around an hour

## Description
Instead of credentials, certificate caching implemented for around an hour

## Related Issue(s)
- #81 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] All tests run green
