### PR TITLE
Set clockskew to 10 seconds

### DIFF
--- a/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
+++ b/src/Altinn.Common.AccessToken/AccessTokenHandler.cs
@@ -144,7 +144,7 @@ public class AccessTokenHandler : AuthorizationHandler<IAccessTokenRequirement>
             ValidateAudience = false,
             RequireExpirationTime = true,
             ValidateLifetime = true,
-            ClockSkew = TimeSpan.Zero
+            ClockSkew = new TimeSpan(0, 0, 10)
         };
 
         tokenValidationParameters.IssuerSigningKeys = await _publicSigningKeyProvider.GetSigningKeys(issuer);

--- a/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
+++ b/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
@@ -99,7 +99,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, -11), "ttd");
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, -11, "ttd");
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
@@ -126,7 +126,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, 5, "ttd");
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
@@ -147,6 +147,33 @@ namespace Altinn.AccessToken.Tests
         }
 
         [Fact]
+        public async Task HandleAsyncTest_TokenNotYetValidAndVerificationEnabled_ResultNotSuccessful()
+        {
+            // Arrange
+            AccessTokenSettings accessTokenSettings = new();
+            _options.Setup(s => s.Value).Returns(accessTokenSettings);
+
+            ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
+            string accessToken = AccessTokenCreator.GenerateToken(principal, 15, 20, "ttd");
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
+
+            _httpContextAccessor.Setup(s => s.HttpContext).Returns(httpContext);
+
+            var context = new AuthorizationHandlerContext(_reqs, PrincipalUtil.CreateClaimsPrincipal(), null);
+
+            var target = new AccessTokenHandler(
+                _httpContextAccessor.Object, _logger.Object, _options.Object, _signingKeysResolver);
+
+            // Act
+            await target.HandleAsync(context);
+
+            // Assert
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
         public async Task HandleAsyncTest_ErrorObtainingKeysAndVerificationEnabled_ResultNotSuccessful()
         {
             // Arrange
@@ -154,7 +181,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, 5, "ttd");
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
@@ -184,7 +211,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), "ttd");
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, 5, "ttd");
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
@@ -216,7 +243,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), tokenIssuer);
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, 5, tokenIssuer);
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;
@@ -250,7 +277,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, 5), tokenIssuer);
+            string accessToken = AccessTokenCreator.GenerateToken(principal, -12, 5, tokenIssuer);
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;

--- a/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
+++ b/test/Altinn.AccessToken.Tests/AccessTokenHandlerTests.cs
@@ -99,7 +99,7 @@ namespace Altinn.AccessToken.Tests
             _options.Setup(s => s.Value).Returns(accessTokenSettings);
 
             ClaimsPrincipal principal = PrincipalUtil.CreateClaimsPrincipal();
-            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, -5), "ttd");
+            string accessToken = AccessTokenCreator.GenerateToken(principal, new TimeSpan(0, 0, -11), "ttd");
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["PlatformAccessToken"] = accessToken;

--- a/test/Altinn.AccessToken.Tests/Mock/AccessTokenCreator.cs
+++ b/test/Altinn.AccessToken.Tests/Mock/AccessTokenCreator.cs
@@ -15,14 +15,14 @@ namespace Altinn.AccessToken.Tests.Mock
         /// Generates a token with a self signed certificate included in the test project.
         /// </summary>
         /// <returns>A new token</returns>
-        public static string GenerateToken(ClaimsPrincipal principal, TimeSpan tokenExipry, string issuer)
+        public static string GenerateToken(ClaimsPrincipal principal, int notBeforeSeconds, int expiresSeconds, string issuer)
         {
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             SecurityTokenDescriptor tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(principal.Identity),
-                Expires = DateTime.UtcNow.AddSeconds(tokenExipry.TotalSeconds),
-                NotBefore = DateTime.UtcNow.AddSeconds(-12),
+                NotBefore = DateTime.UtcNow.AddSeconds(notBeforeSeconds),
+                Expires = DateTime.UtcNow.AddSeconds(expiresSeconds),
                 SigningCredentials = GetSigningCredentials(issuer),
                 Audience = "altinn.no",
                 Issuer = issuer

--- a/test/Altinn.AccessToken.Tests/Mock/AccessTokenCreator.cs
+++ b/test/Altinn.AccessToken.Tests/Mock/AccessTokenCreator.cs
@@ -22,7 +22,7 @@ namespace Altinn.AccessToken.Tests.Mock
             {
                 Subject = new ClaimsIdentity(principal.Identity),
                 Expires = DateTime.UtcNow.AddSeconds(tokenExipry.TotalSeconds),
-                NotBefore = DateTime.UtcNow.AddSeconds(-10),
+                NotBefore = DateTime.UtcNow.AddSeconds(-12),
                 SigningCredentials = GetSigningCredentials(issuer),
                 Audience = "altinn.no",
                 Issuer = issuer


### PR DESCRIPTION
## Description
Set clockskew to 10 seconds when validating tokens to avoid problems if the caller's clock is slightly ahead of the validator's.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
