### PR TITLE
Remove cache Sonarcloud packages

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -41,12 +41,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
         uses: actions/cache@v4

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -41,26 +41,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache SonarCloud scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v4
-        with:
-          path: .\.sonar\scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarCloud scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+          dotnet tool install --global dotnet-sonarscanner
       - name: Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"Altinn_altinn-accesstoken" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.coverage.exclusions="src/**/Program.cs"
+          dotnet-sonarscanner begin /k:"Altinn_altinn-accesstoken" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.coverage.exclusions="src/**/Program.cs"
 
           dotnet build Altinn.Common.AccessToken.sln
           dotnet test Altinn.Common.AccessToken.sln `
@@ -69,4 +60,4 @@ jobs:
           --collect:"XPlat Code Coverage" `
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
## Description
Removes superfluous caching steps of Sonar packages in the build pipeline
- Step `Cache SonarCloud packages` [isn't working](https://github.com/Altinn/altinn-accesstoken/actions/runs/13262102779/job/37020815678#step:5:15)
- Step `Cache SonarCloud scanner` is redundant
  - Verified by the same output from the "Analyze" step (`INFO: User cache: C:\Users\runneradmin\.sonar\cache`) [before](https://github.com/Altinn/altinn-accesstoken/actions/runs/13368621938/job/37331964958#step:7:90) vs [after](https://github.com/Altinn/altinn-accesstoken/actions/runs/13369800499/job/37335610381#step:6:90) removing the custom cache step
  - seems to speed up the Analyze job by ~10 secs

## Related Issue(s)
[#153](https://github.com/Altinn/team-core-private/issues/153) (team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
