### PR TITLE
Restrict wildcard CODEOWNERS entry to the CODEOWNERS file itself

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @altinn/team-core
+/.github/CODEOWNERS @altinn/team-core


### PR DESCRIPTION
## Description
To reduce unwanted notifications from GitHub to everyone on the team

## Related Issue(s)
- [323](https://github.com/orgs/Altinn/projects/20/views/11?filterQuery=&pane=issue&itemId=128610640&issue=Altinn%7Cteam-core-private%7C323)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
