### PR TITLE
Restrict write permission in build workflows

### DIFF
--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
     name: Build and Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Setup .NET

--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -1,6 +1,5 @@
 name: Code test and analysis (fork)
-permissions:
-  contents: read
+permissions: {}
 on:
   push:
     branches: [main]

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -28,6 +28,9 @@ jobs:
     if: ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'push') && github.repository_owner == 'Altinn'
     name: Analyze
     runs-on: windows-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,12 +1,10 @@
 name: Code test and analysis
-permissions:
-  contents: read
-  checks: write
+permissions: {}
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
     types: [opened, synchronize, reopened]
 jobs:
   build-and-test:
@@ -23,8 +21,8 @@ jobs:
             9.0.x
       - name: Build & Test
         run: |
-           dotnet build Altinn.Common.AccessToken.sln -v m
-           dotnet test Altinn.Common.AccessToken.sln -v m
+          dotnet build Altinn.Common.AccessToken.sln -v m
+          dotnet test Altinn.Common.AccessToken.sln -v m
   analyze:
     if: ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'push') && github.repository_owner == 'Altinn'
     name: Analyze
@@ -43,14 +41,14 @@ jobs:
           java-version: 17
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install SonarCloud scanner
         shell: powershell
         run: |
           dotnet tool install --global dotnet-sonarscanner
       - name: Analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,5 +1,6 @@
 name: Code test and analysis
-permissions: {}
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Description
Follow the principle of least privilege in GITHUB_TOKEN permission grants for the build workflows. Avoids job inheritance of permissions that they don't need, by using restrictive top-level defaults and setting special permissions only on the jobs that require it.

## Related Issue(s)
N/A
